### PR TITLE
Doubled-up slashes in base-url no longer accepted by Bubble

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -48,8 +48,8 @@ export const config = {
   },
   getBaseUrl(): string {
     return `https://${globalConfig.domain}/${
-      globalConfig.isLive ? '' : 'version-test'
-    }/api/1.1/`;
+      globalConfig.isLive ? '' : 'version-test/'
+    }api/1.1`;
   },
 };
 


### PR DESCRIPTION
The Bubble api is now returning a 404 error when slashes are doubled up in the URL. This removes the doubled-up slashes. 

Example URL Before PR:
https://hub.brilliantmetrics.com//api/1.1//obj/myobject

Example URL After PR:
https://hub.brilliantmetrics.com/api/1.1/obj/invoiceline